### PR TITLE
Fix test_attribute_setting_doc_read on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import random
 import tempfile
 
@@ -42,10 +43,11 @@ def build_module_mock(mocker):
             module.__file__ = path
         else:
             tmp_file = tempfile.NamedTemporaryFile(
-                mode='w+', prefix=f'tmp_{name}', suffix='.py'
+                mode='w+', prefix=f'tmp_{name}', suffix='.py', delete=False
             )
             tmp_file.write(code)
             tmp_file.flush()
+            tmp_file.close()
             module.__file__ = tmp_file.name
             tmp_files.append(tmp_file)
         sys.modules[name] = module
@@ -55,7 +57,7 @@ def build_module_mock(mocker):
     yield _make_module
 
     for f in tmp_files:
-        f.close()
+        os.remove(f.name)
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes a small problem with `build_module_mock` which causes the test `test_attribute_setting_doc_read` to fail on Windows.

Currently `test_attribute_setting_doc_read` fails with a `PermissionError` on Windows:
```
================================== FAILURES ===================================
_______________________ test_attribute_setting_doc_read _______________________

build_module_mock = <function build_module_mock.<locals>._make_module at 0x00000220D4273670>
test_settings_with_docs_module = '\nfrom concrete_settings import Settings\n\nclass TestSettings(Settings):\n    #: This is doc\n    #: For max_speed\n    MAX_SPEED = 10\n'

    def test_attribute_setting_doc_read(build_module_mock, test_settings_with_docs_module):
>       build_module_mock('test_settings_module', test_settings_with_docs_module)

test_docreader.py:18: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
conftest.py:52: in _make_module
    exec(code, module.__dict__)
<string>:4: in <module>
    ???
..\concrete_settings\core.py:164: in __new__
    mcs._add_settings_help(name, new_dict)
..\concrete_settings\core.py:258: in _add_settings_help
    comments = extract_doc_comments_from_class_or_module(cls_module_name, cls_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

module_name = 'test_settings_module', cls_name = 'TestSettings'

    def extract_doc_comments_from_class_or_module(module_name, cls_name=None):
        # read the contents of the module which contains the settings
        # and parse it via Sphinx parser
        module_path = getattr(sys.modules[module_name], '__file__', None)
        if not module_path or not os.path.exists(module_path):
            return {}
    
>       with open(module_path, 'r') as f:
E       PermissionError: [Errno 13] Permission denied: 'C:\\Users\\User\\AppData\\Local\\Temp\\tmp_test_settings_module8go5vrsq.py'

..\concrete_settings\docreader.py:13: PermissionError
```
The reason is that you can't open a file a second time, e.g. for reading, when it has already been opened for writing. It must be closed first. It's a pretty common problem with reading/writing to files on Windows systems.

The solution is in three steps:

1. Pass `delete=False` to `NamedTemporaryFile`, so that the temporary file is not deleted on `close()`
2. Close the temporary file after it has been created and we are done writing to it
3. Delete the file on teardown, since (because of step 1) it won't be deleted anymore on `close()`

This *should* work also on Linux, but I didn't have the ability to test it.